### PR TITLE
Small patch to allow to work with OS command output using UTF8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: clean-pyc clean-build clean
+
+help:
+	@echo "clean         - remove all build artifacts"
+	@echo "clean-build   - remove build artifacts"
+	@echo "clean-pyc     - remove Python file artifacts"
+
+clean: clean-build clean-pyc clean-test
+	find . -name '*~' -exec rm -f {} +
+
+clean-build:
+	rm -rf build/
+	rm -rf dist/
+	rm -rf .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+	find . -name '*~' -exec rm -f {} +
+
+clean-test:
+	rm -rf .tox/
+	rm -f .coverage
+	rm -rf htmlcov/
+
+

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -55,7 +55,7 @@ def run(command, log=True):
         raise error
     else:
         if output and log:
-            print('{}\n{}'.format(' '.join(command), output))
+            print('{}\n{}'.format(' '.join(command), output.decode('utf8')))
         else:
             print(' '.join(command))
     return output

--- a/{{cookiecutter.cookiecutter_slug}}/Makefile
+++ b/{{cookiecutter.cookiecutter_slug}}/Makefile
@@ -1,0 +1,29 @@
+.PHONY: clean-pyc clean-build clean
+
+help:
+	@echo "clean         - remove all build artifacts"
+	@echo "clean-build   - remove build artifacts"
+	@echo "clean-pyc     - remove Python file artifacts"
+
+clean: clean-build clean-pyc clean-test
+	find . -name '*~' -exec rm -f {} +
+
+clean-build:
+	rm -rf build/
+	rm -rf dist/
+	rm -rf .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+	find . -name '*~' -exec rm -f {} +
+
+clean-test:
+	rm -rf .tox/
+	rm -f .coverage
+	rm -rf htmlcov/
+
+

--- a/{{cookiecutter.cookiecutter_slug}}/hooks/post_gen_project.py
+++ b/{{cookiecutter.cookiecutter_slug}}/hooks/post_gen_project.py
@@ -55,7 +55,7 @@ def run(command, log=True):
         raise error
     else:
         if output and log:
-            print('{}\n{}'.format(' '.join(command), output))
+            print('{}\n{}'.format(' '.join(command), output.decode('utf8')))
         else:
             print(' '.join(command))
     return output


### PR DESCRIPTION
@tuxredux in my UBUNTU with locales configured for Brazil, the following error occurred:

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 23: ordinal not in range(128)`

This PR resolves solves the problem, at least for my case.

I've also added a Makefile to make it easier to clean up backup and temporary files that may interfere with cookiecutter operation, especially if they are in the hooks directory.
